### PR TITLE
添加 SQLite 后端适配器及多 LLM 部署指南

### DIFF
--- a/contrib/sqlite_backend/README.md
+++ b/contrib/sqlite_backend/README.md
@@ -1,0 +1,45 @@
+# SQLite 后端适配器
+
+让 SciAssistant 脱离 MySQL，使用 SQLite 运行。适合本地开发、测试和轻量部署。
+
+## 使用方式
+
+```bash
+# 1. 初始化数据库
+python contrib/sqlite_backend/init_db.py
+
+# 2. 在 app.py 或启动脚本最开头导入适配器
+```
+
+在你的启动脚本中：
+
+```python
+import sys
+sys.path.insert(0, 'contrib/sqlite_backend')
+import adapter  # 此后 pymysql.connect 自动路由到 SQLite
+
+# 然后正常 import app
+from app import app
+app.run()
+```
+
+## 原理
+
+`adapter.py` 通过 monkey-patch 替换 `pymysql` 模块：
+
+- `pymysql.connect()` → SQLite 连接
+- `pymysql.cursors.DictCursor` → SQLite Row 对象（已支持类字典访问）
+- MySQL 专有语法（AUTO_INCREMENT、ENGINE、enum 等）→ SQLite 兼容语法
+- `NOW()` → `datetime('now')`
+
+## 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `SQLITE_DB_PATH` | `data/sciassist.db` | 数据库文件路径 |
+
+## 限制
+
+- 不支持 MySQL 高级特性（存储过程、触发器等）
+- 并发写入性能低于 MySQL
+- 生产环境建议仍使用 MySQL

--- a/contrib/sqlite_backend/adapter.py
+++ b/contrib/sqlite_backend/adapter.py
@@ -1,0 +1,116 @@
+"""
+pymysql → sqlite3 适配器
+
+让 SciAssistant 在无 MySQL 环境下运行。导入此模块后自动生效。
+
+用法:
+    import sys
+    sys.path.insert(0, 'contrib/sqlite_backend')
+    import adapter  # 此后 pymysql 调用自动路由到 SQLite
+
+数据库路径通过环境变量 SQLITE_DB_PATH 设置，默认 ./data/sciassist.db
+"""
+import sqlite3
+import sys, re, os
+
+DB_PATH = os.environ.get('SQLITE_DB_PATH', os.path.join(os.path.dirname(__file__), '..', '..', 'data', 'sciassist.db'))
+os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+
+
+class SQLiteCursor:
+    def __init__(self, sqlite_conn):
+        self._c = sqlite_conn.cursor()
+        self._conn = sqlite_conn
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def execute(self, sql, args=None):
+        sql = self._xlate(sql)
+        try:
+            if args: self._c.execute(sql, args)
+            else:   self._c.execute(sql)
+        except Exception as e:
+            raise type(e)(f"{e}\n  SQL: {sql[:200]}")
+
+    def fetchone(self):
+        row = self._c.fetchone()
+        self._c.connection.commit()
+        return row
+
+    def fetchall(self):
+        rows = self._c.fetchall()
+        self._c.connection.commit()
+        return rows
+
+    def close(self): pass
+
+    @property
+    def lastrowid(self):
+        return self._c.lastrowid
+
+    def __iter__(self):
+        return self._c.__iter__()
+
+    def _xlate(self, sql):
+        s = sql
+        for pattern, repl in [
+            (r'(?i)AUTO_INCREMENT\s*=\s*\d+', ''),
+            (r'(?i)AUTO_INCREMENT', 'AUTOINCREMENT'),
+            (r'(?i)CHARACTER SET \w+', ''),
+            (r'(?i)COLLATE \w+', ''),
+            (r'(?i)ENGINE=\w+', ''),
+            (r'(?i)ROW_FORMAT\s*=\s*\w+', ''),
+            (r'mediumtext', 'text'),
+            (r'tinyint\(1\)', 'integer'),
+            (r'bigint', 'integer'),
+            (r"enum\([^)]+\)", 'varchar(20)'),
+            (r'(?i)datetime', 'timestamp'),
+            (r"(?i)DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP", ''),
+            (r"(?i)ON UPDATE CURRENT_TIMESTAMP", ''),
+            (r"(?i)INDEX \w+\([^)]+\) USING \w+", ''),
+            (r'%s', '?'),
+        ]:
+            s = re.sub(pattern, repl, s)
+        s = s.replace('NOW()', "datetime('now')").replace('now()', "datetime('now')")
+        return s
+
+
+class SQLiteConnection:
+    def __init__(self, **kwargs):
+        self._conn = sqlite3.connect(DB_PATH)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+
+    def cursor(self):
+        return SQLiteCursor(self._conn)
+
+    def commit(self):   self._conn.commit()
+    def rollback(self): self._conn.rollback()
+    def close(self):    self._conn.close()
+
+
+class DictCursor(SQLiteCursor):
+    pass
+
+
+class CursorsModule:
+    DictCursor = DictCursor
+
+
+class FakePymysql:
+    connect = staticmethod(lambda *a, **kw: SQLiteConnection(**kw))
+    cursors = CursorsModule()
+    MySQLError = type('MySQLError', (Exception,), {})
+    IntegrityError = type('IntegrityError', (MySQLError,), {})
+    OperationalError = type('OperationalError', (MySQLError,), {})
+
+    def __getattr__(self, name):
+        return None
+
+
+sys.modules['pymysql'] = FakePymysql()
+sys.modules['pymysql.cursors'] = CursorsModule()

--- a/contrib/sqlite_backend/init_db.py
+++ b/contrib/sqlite_backend/init_db.py
@@ -1,0 +1,60 @@
+"""初始化 SQLite 数据库，创建 SciAssistant 所需表结构"""
+import sqlite3, os, sys
+
+def init_database(db_path=None):
+    if db_path is None:
+        db_path = os.environ.get('SQLITE_DB_PATH',
+            os.path.join(os.path.dirname(__file__), '..', '..', 'data', 'sciassist.db'))
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username VARCHAR(50) NOT NULL UNIQUE,
+      email VARCHAR(100) NOT NULL UNIQUE,
+      password VARCHAR(255) NOT NULL,
+      avatar VARCHAR(255),
+      createtime TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      uptimestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS chat_list (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      session_id VARCHAR(50) NOT NULL,
+      title VARCHAR(100) NOT NULL,
+      create_time TIMESTAMP,
+      update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS conversation_detail (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id VARCHAR(50) NOT NULL,
+      from_who VARCHAR(4) NOT NULL,
+      round INTEGER DEFAULT 1,
+      timestamp TIMESTAMP NOT NULL,
+      uuid VARCHAR(100),
+      content TEXT NOT NULL,
+      think_msg TEXT,
+      create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      has_report INTEGER DEFAULT NULL,
+      report_title VARCHAR(255) DEFAULT '研究报告'
+    );
+    CREATE TABLE IF NOT EXISTS user_files (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      file_id VARCHAR(64) NOT NULL UNIQUE,
+      user_id INTEGER NOT NULL,
+      original_filename VARCHAR(255) NOT NULL,
+      stored_filename VARCHAR(255) NOT NULL,
+      file_path VARCHAR(512) NOT NULL,
+      file_size INTEGER NOT NULL,
+      file_type VARCHAR(10) NOT NULL,
+      status VARCHAR(20) DEFAULT 'processing',
+      upload_time TIMESTAMP NOT NULL,
+      process_time TIMESTAMP
+    );
+    """)
+    conn.commit()
+    conn.close()
+    print(f"SQLite 数据库已初始化: {db_path}")
+
+if __name__ == '__main__':
+    init_database()

--- a/contrib/sqlite_backend/run_local.py
+++ b/contrib/sqlite_backend/run_local.py
@@ -1,0 +1,22 @@
+"""SciAssistant 本地启动脚本（SQLite + 自定义 LLM）"""
+import sys, os
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, BASE_DIR)
+sys.path.insert(0, os.path.join(BASE_DIR, 'deepdiver_v2'))
+
+# 加载 SQLite 适配器（必须在 import app 之前）
+sys.path.insert(0, os.path.join(BASE_DIR, 'contrib', 'sqlite_backend'))
+import adapter
+
+os.environ.setdefault('FLASK_DEBUG', 'true')
+
+import importlib.util
+spec = importlib.util.spec_from_file_location("app", os.path.join(BASE_DIR, "app.py"))
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+PORT = int(os.environ.get('PORT', 5050))
+print(f"\n  SciAssistant 已启动: http://127.0.0.1:{PORT}")
+print(f"  数据库: SQLite ({os.environ.get('SQLITE_DB_PATH', '默认路径')})\n")
+m.app.run(host='127.0.0.1', port=PORT, debug=False)

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,64 @@
+# 本地部署指南
+
+在本地环境中运行 SciAssistant，支持两种数据库后端。
+
+## 环境要求
+
+- Python 3.11+
+- MySQL 5.7+（生产模式）或 SQLite 3（开发模式）
+- 兼容 OpenAI API 的 LLM 服务
+
+## 快速开始（SQLite + DeepSeek）
+
+```bash
+# 1. 克隆项目
+git clone https://github.com/scsio-marinebio/SciAssistant.git
+cd SciAssistant
+
+# 2. 安装依赖
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r deepdiver_v2/requirements.txt
+
+# 3. 初始化数据库
+python contrib/sqlite_backend/init_db.py
+
+# 4. 配置 LLM（复制模板后编辑）
+cp deepdiver_v2/config/.env.template deepdiver_v2/config/.env
+# 编辑 .env 填入 MODEL_REQUEST_URL 和 MODEL_REQUEST_TOKEN
+# 参考 docs/LLM_CONFIG.md
+
+# 5. 用提供的启动脚本运行
+python contrib/sqlite_backend/run_local.py
+```
+
+浏览器打开 `http://127.0.0.1:5050`，注册账号即可使用。
+
+## MySQL 模式（生产）
+
+```bash
+# 1. 安装 MySQL
+sudo apt install mysql-server
+
+# 2. 创建数据库
+mysql -u root -p -e "CREATE DATABASE sciassist CHARACTER SET utf8mb4;"
+
+# 3. 导入表结构
+mysql -u root -p sciassist < chatai.sql
+
+# 4. 修改 app.py 中的 DB_CONFIG
+# 编辑 DB_CONFIG 字典填入你的 MySQL 连接信息
+```
+
+## 常见问题
+
+### Q: 注册时报 500 错误
+检查数据库是否已初始化：`ls data/sciassist.db`
+如果使用 SQLite 模式，确保在导入 app 之前先导入了 `adapter.py`
+
+### Q: 聊天提示"获取响应失败"
+1. 检查 LLM API 密钥和端点是否正确
+2. 查看服务器日志中的错误请求地址——端口或模型名可能不匹配
+3. 确认前端 `ai_chat.html` 中的模型名与 `.env` 中一致
+
+### Q: 前端页面 404
+确保 `chatAi/` 目录在项目根目录下。如果自定义了路径，需要修改 `app.py` 中的静态文件路由。

--- a/docs/LLM_CONFIG.md
+++ b/docs/LLM_CONFIG.md
@@ -1,0 +1,60 @@
+# 多 LLM 后端配置指南
+
+SciAssistant 通过 litellm 支持接入任意 OpenAI 兼容 API。本文档说明如何配置不同的 LLM 后端。
+
+## 配置方式
+
+编辑 `deepdiver_v2/config/.env`：
+
+```bash
+MODEL_REQUEST_URL=<API 端点>
+MODEL_REQUEST_TOKEN=<API 密钥>
+MODEL_NAME=<模型名称>
+```
+
+## DeepSeek
+
+```bash
+MODEL_REQUEST_URL=https://api.deepseek.com/v1/chat/completions
+MODEL_REQUEST_TOKEN=sk-your-key
+MODEL_NAME=deepseek-v4-pro
+```
+
+## 通义千问 (Qwen)
+
+通过阿里云百炼平台：
+
+```bash
+MODEL_REQUEST_URL=https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions
+MODEL_REQUEST_TOKEN=sk-your-key
+MODEL_NAME=qwen-plus
+```
+
+## OpenAI
+
+```bash
+MODEL_REQUEST_URL=https://api.openai.com/v1/chat/completions
+MODEL_REQUEST_TOKEN=sk-your-key
+MODEL_NAME=gpt-4o
+```
+
+## 本地模型 (Ollama)
+
+```bash
+MODEL_REQUEST_URL=http://localhost:11434/v1/chat/completions
+MODEL_REQUEST_TOKEN=ollama
+MODEL_NAME=qwen2.5:14b
+```
+
+## 前端模型名修改
+
+如果使用非盘古模型，需同步修改前端 JavaScript 中的模型名。在 `chatAi/ai_chat.html` 中搜索 `"model"`：
+
+```javascript
+// 将所有 "model":"pangu" 或 "model":"pangu_auto" 改为你的模型名
+"model":"deepseek-v4-pro"
+```
+
+## 验证
+
+配置完成后启动服务，在 Chat 模式下发送消息，查看服务器日志确认请求发送到了正确的 API 端点。


### PR DESCRIPTION
本 PR 新增 SQLite 数据库后端适配器，让 SciAssistant 无需 MySQL 即可运行，同时补充部署指南和多 LLM 配置文档。新增文件：contrib/sqlite_backend/ (适配器+初始化+启动脚本+文档) 和 docs/ (DEPLOY.md + LLM_CONFIG.md)。三种模式已在 SQLite + DeepSeek V4 Pro 环境下验证通过。